### PR TITLE
Add instanced methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,17 @@ Flags can also be scoped to a class by creating a new `FunctionFlags` instance. 
 ```php
 use FunctionFlags/FunctionFlags
 
-$my_flag = new FunctionFlags("MY_FLAG");
-$other_flag = new FunctionFlags("OTHER_FLAG");
+$flags1 = new FunctionFlags(["FOO", "BAR"]);
+$flags2 = new FunctionFlags(["BAR", "BIZ"]);
 
-// Returns true if MY_FLAG is passed and present in $my_flag
+// Returns true if FOO is passed and present in $flags1
 function foo(int $flags = null): bool {
-  return $my_flag->isset(MY_FLAG);
+  return $flags2->isset(FOO);
 }
 
-foo(MY_FLAG); // true
-foo(OTHER_FLAG|MY_FLAG); // true
-foo(OTHER_FLAG); // false
+foo(FOO); // true
+foo(FOO|BIZ); // true
+foo(BIZ); // false
 foo(); // false
 ```
 

--- a/src/FunctionFlags.php
+++ b/src/FunctionFlags.php
@@ -125,7 +125,6 @@
 
         // Check if flag is set within instance scope
         private function inst_isset(int $flag): bool|null {
-            $test = $this::static_isset($flag);
             // Filter flags that belong to this scope
             return in_array($this::static_isset($flag), $this->flags);
         }

--- a/src/FunctionFlags.php
+++ b/src/FunctionFlags.php
@@ -1,16 +1,70 @@
 <?php
 
-		namespace FunctionFlags;
+	namespace FunctionFlags;
     
     class FunctionFlags {
         // Limit value for debug_backtrace()
         private static $trace_limit = 5;
 
+        // Methods by name that can be called statically
+        private static $static_public_whitelist = [
+            "static_define",
+            "static_isset"
+        ];
+
+        // Methods by name that can be called when instanced
+        private static $inst_public_whitelist = [
+            "inst_define",
+            "inst_isset"
+        ];
+
+        public function __construct(string|array $flags = null) {
+            // This array will contain instance defined flags
+            $this->flags = [];
+
+            // Define flags that were initialized with this class
+            if (!empty($flags)) {
+                $this->inst_define($flags);
+            }
+        }
+
+        // We're using the PHP __call() and __callStatic() magic functions here in order to allow
+        // methods to be called with the same name downstream. inst_define() and static_define() can
+        // be called using FunctionFlags::define() and FunctionFlags->define().
+
+        // Call static method on this class
+        public static function __callStatic(string $method, array $args): mixed {
+            // Static methods use this method prefix
+            $method_prefixed = "static_" . $method;
+
+            // Check that method exists on this class and is in whitelist of public static methods
+            if (!in_array($method_prefixed, get_class_methods(__CLASS__)) && !in_array($method_prefixed, (__CLASS__)::$static_public_whitelist)) {
+                throw new \BadMethodCallException("Method '${method}' does not exist");
+            }
+
+            return (__CLASS__)::{$method_prefixed}(...$args);
+        }
+
+        // Call instanced method on this class
+        public function __call(string $method, array $args): mixed {
+            // Instanced methods use this method prefix
+            $method_prefixed = "inst_" . $method;
+
+            // Check that method exists on this class and is in whitelist of public instanced methods
+            if (!in_array($method_prefixed, get_class_methods(__CLASS__)) && !in_array($method_prefixed, (__CLASS__)::$inst_public_whitelist)) {
+                throw new \BadMethodCallException("Method '${method}' does not exist");
+            }
+
+            return $this->{$method_prefixed}(...$args);
+        }
+
+        /* ---- */
+
         // Reserve a constant address space
         private static function addr_reserve(): int {
             // Set initial value when first flag is defined
             if (empty($_ENV[__CLASS__])) {
-                $_ENV[__CLASS__] = 0;
+                $_ENV[__CLASS__] = 1;
             }
 
             // Increment counter
@@ -21,18 +75,18 @@
 
         // Get flags from caller closest to this method on the call stack
         private static function get_flags_from_caller(): int|null {
-            // Get call stack
-            $stack = debug_backtrace(0, (__CLASS__)::$trace_limit);
+            // Get call stack in reverse order
+            $stack = array_reverse(debug_backtrace(0, (__CLASS__)::$trace_limit));
 
-            // Extract class names from callstack in reverse order and find the first occurance of this class in the backtrace
-            $idx = array_search(__CLASS__, array_reverse(array_column($stack, "class")));
+            // Find first occurance of this class name in callstack
+            $idx = array_search(__CLASS__, array_column($stack, "class"));
             // Failed to locate this class in a full backtrace
             if ($idx === false) {
                 throw new Exception("Failed to retrieve flags from initator callable");
             }
 
-            // Get args array from stack entry by index
-            $args = $stack[$idx]["args"];
+            // Get args array from initial caller by simply stepping back one entry in the reverse array
+            $args = $stack[$idx - 1]["args"];
 
             // Return null if no arguments provided or not a valid int flag
             return !empty($args) && is_int(end($args)) ? end($args) : null;
@@ -41,7 +95,7 @@
         /* ---- */
 
         // Define new constants
-        public static function define(string|array $flags) {
+        private static function static_define(string|array $flags) {
             // Convert to array
             $flags = is_array($flags) ? $flags : [$flags];
 
@@ -52,8 +106,27 @@
         }
 
         // Check if a flag is set with bitwise AND of all flags
-        public static function isset(int $flag): bool|null {
-            $flags = FunctionFlags::get_flags_from_caller();
+        private static function static_isset(int $flag): bool|null {
+            $flags = (__CLASS__)::get_flags_from_caller();
             return $flags ? $flags & $flag : null;
+        }
+
+        /* ---- */
+
+        private function inst_define(string|array $flags) {
+            // Convert to array
+            $flags = is_array($flags) ? $flags : [$flags];
+
+            // Define constants
+            $this::static_define($flags);
+            // Append flag(s) to instance memory
+            $this->flags = array_merge($this->flags, $flags);
+        }
+
+        // Check if flag is set within instance scope
+        private function inst_isset(int $flag): bool|null {
+            $test = $this::static_isset($flag);
+            // Filter flags that belong to this scope
+            return in_array($this::static_isset($flag), $this->flags);
         }
     }

--- a/src/FunctionFlags.php
+++ b/src/FunctionFlags.php
@@ -126,13 +126,14 @@
         }
 
         // Check if a flag is set with bitwise AND of all flags
-        private static function static_isset(int $flag): bool|null {
+        private static function static_isset(int $flag): bool {
             $flags = (__CLASS__)::get_flags_from_caller();
-            return $flags ? $flags & $flag : null;
+            return $flags ? $flags & $flag : false;
         }
 
         /* ---- */
 
+        // Define flag(s) for $this instance
         private function inst_define(string|array $flags) {
             // Convert to array
             $flags = is_array($flags) ? $flags : [$flags];
@@ -141,8 +142,9 @@
             $this->flags = array_merge($this->flags, $this::static_define($flags));
         }
 
-        // Check if flag is set within instance scope
-        private function inst_isset(int $flag): bool|null {
+        // Check if flag is set and within $this scope
+        private function inst_isset(int $flag): bool {
+            // Return false if the flag is not in scope of $this instance
             if (!in_array($flag, $this->flags)) {
                 return false;
             }


### PR DESCRIPTION
This PR implements the instanced methods desribed in the README (before they were added 😳)

~~This is however kind of useless.. since all PHP constants are scoped globally by nature, it's not possible to define two constants with the same name (or in this instance "flag") - and that kinda defeats the purpose of having them scoped in the first place.~~

~~So before merge it might be more prudent to just expose the instanced methods as aliases for their static counterpart.~~

Edit: Instanced functionality now behaves as expected. There IS a way to scope constants artifically, which is what I have done here. 